### PR TITLE
Optimization of civ_interact

### DIFF
--- a/addons/civ_interact/eventhandlers.hpp
+++ b/addons/civ_interact/eventhandlers.hpp
@@ -1,7 +1,8 @@
+#include "script_component.hpp"
 class Extended_Init_EventHandlers {
-	class Man {
-		class COMPONENT {
-			init = "_this call SpyderAddons_fnc_addCivilianAction";
+	class Civilian {
+		class ADDON {
+			clientInit = QUOTE(_this call SpyderAddons_fnc_addCivilianAction);
 		};
 	};
 };

--- a/addons/civ_interact/fnc_addCivilianAction.sqf
+++ b/addons/civ_interact/fnc_addCivilianAction.sqf
@@ -1,23 +1,4 @@
 params ["_unit"];
-
-if (!isServer) exitWith {_this remoteExecCall ["SpyderAddons_fnc_addCivilianAction",2]};
 if ((side _unit != civilian) or (isNil "SpyderAddons_civInteract_Logic")) exitWith {};
 
-[[[_unit],{
-	if (hasInterface) then {
-		params ["_unit"];
-		_unit addAction ["Interact", "['openMenu', [_this select 0]] call SpyderAddons_fnc_civInteract", "", 50, true, false, "", "alive _target"];
-	};
-}],"BIS_fnc_spawn",true] call BIS_fnc_MP;
-
-/* --------
-[
-	[[_unit],
-	{
-		if (hasInterface) then {
-			params ["_unit"];
-			_unit addAction ["Interact", "['openMenu', [_this select 0]] call SpyderAddons_fnc_civInteract", "", 50, true, false, "", "alive _target"];
-		};
-	}]
-] remoteExecCall ["BIS_fnc_spawn",0];
--------- */
+_unit addAction ["Interact", "['openMenu', [_this select 0]] call SpyderAddons_fnc_civInteract", "", 50, true, false, "", "alive _target"];

--- a/addons/civ_interact/script_component.hpp
+++ b/addons/civ_interact/script_component.hpp
@@ -1,4 +1,5 @@
 #define COMPONENT civ_interact
+//#define DEBUG_MODE_FULL
 #include <\x\spyderaddons\addons\main\script_mod.hpp>
 
 #include <\x\cba\addons\main\script_macros.hpp>

--- a/addons/main/script_mod.hpp
+++ b/addons/main/script_mod.hpp
@@ -1,5 +1,6 @@
 #define PREFIX SpyderAddons
 #define RECOMPILE 1
+//#define DEBUG_MODE_FULL
 
 #define MOD(var1) SpyderAddons_##var1		//-- SpyderAddons_var1
 #define QMOD(var1) QUOTE(SpyderAddons_##var1)	//-- "SpyderAddons_var1"


### PR DESCRIPTION
- Changed the way the action gets attached to civilians. Now using 'clientInit' instead of 'init' since the action does not need to get broadcasted to the server.
- Action only gets attached to objects that inherit from 'Civilian' and not 'Man'. Helps narrow the search and optimizes.
- Removed redundant code from 'fnc_addCivilianAction.sqf'
