### PR TITLE
Get faction headgear hotfix

### DIFF
--- a/addons/mil_detection/fnc_detection.sqf
+++ b/addons/mil_detection/fnc_detection.sqf
@@ -148,7 +148,7 @@ switch (_operation) do {
 		_uniformFactionsIncognito = "(configName _x) in _incognitoUniforms" configClasses (configFile >> "CfgFactionClasses");
 
 		//-- Get faction headgear
-		if !(count _headgearIncognito == 0) then {
+		if !(count _headgearFactionsIncognito == 0) then {
 			_factionNames = [];
 			{_factionNames pushBack (configName _x)} forEach _headgearFactionsIncognito;
 			_gear = ["getFactionGear", ["headgear", _factionNames]] call MAINCLASS;


### PR DESCRIPTION
'_headgearIncognito' should be '_headgearFactionsIncognito'. This is currently an issue in stable version and breaks the 'Restricted Headgear' parameter in the Detection module.
